### PR TITLE
API rate limiting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/backend/manage.py",
             "python": "${workspaceFolder}/backend/.venv/bin/python",
-            "args": ["runserver", "8001"],
+            "args": ["runserver", "8000"],
             "django": true
         }
     ]

--- a/backend/backend_site/settings.py
+++ b/backend/backend_site/settings.py
@@ -17,6 +17,7 @@ from celery.schedules import crontab
 
 from .settings_local import (
     ALLOWED_HOSTS,
+    CACHES,
     DATABASES,
     DEBUG,
     DJANGO_LOG_LEVEL,
@@ -44,6 +45,9 @@ TSOSI_OPTIONAL_SETTINGS = [
     "TSOSI_REDIS_PORT",
     # Following settings have defaults
     "TSOSI_TRIGGER_JOBS",
+    # API Rate limiting
+    "TSOSI_API_RATE",
+    "TSOSI_API_WHITELIST_IPS",
 ]
 
 settings_local_module = importlib.import_module("backend_site.settings_local")
@@ -246,6 +250,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 20,
+    "DEFAULT_THROTTLE_CLASSES": ["tsosi.api.throttle.TsosiThrottle"],
 }
 
 TSOSI_CELERY_ACCEPT_CONTENT = ["json"]

--- a/backend/backend_site/settings_local.dev.py
+++ b/backend/backend_site/settings_local.dev.py
@@ -22,6 +22,7 @@ MEDIA_ROOT = f"{NO_GIT_DIR}/media/"
 MEDIA_URL = "media/"
 STATIC_URL = "static/"
 ALLOWED_HOSTS = ["127.0.0.1", "172.17.0.1", "localhost"]
+
 TSOSI_MAIN_LOG_FILE = f"{NO_GIT_DIR}/logs/tsosi_app.log"
 TSOSI_DATA_LOG_FILE = f"{NO_GIT_DIR}/logs/tsosi_data.log"
 TSOSI_DJANGO_LOG_FILE = f"{NO_GIT_DIR}/logs/django.log"
@@ -42,6 +43,13 @@ TSOSI_SCIPOST_AUTH = {
     "password": "",
     "client_id": "",
     "client_secret": "",
+}
+TSOSI_API_WHITELIST_IPS = ["127.0.0.1"]
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://{TSOSI_REDIS_HOST}:{TSOSI_REDIS_PORT}/{TSOSI_REDIS_DB}",
+    }
 }
 
 if "test" in sys.argv or "pytest" in sys.modules:

--- a/backend/init.sh
+++ b/backend/init.sh
@@ -5,6 +5,10 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 cd $SCRIPT_DIR
 
+# This need to be re-run once the container is connected to
+# bc poetry config is user-dependent. The one from the docker is not read here.
+poetry config virtualenvs.in-project true
+
 # Install python deps
 echo -e "\nInstalling Python dependencies"
 poetry install --no-root

--- a/backend/tsosi/api/throttle.py
+++ b/backend/tsosi/api/throttle.py
@@ -1,0 +1,48 @@
+from urllib.parse import urlparse
+
+from django.conf import settings
+from rest_framework.request import Request
+from rest_framework.throttling import AnonRateThrottle
+from tsosi.app_settings import app_settings
+
+
+def is_origin_whitelist(origin: str | None) -> bool:
+    """Whether the given origin URL is allowed."""
+    if origin is None or origin == "":
+        return False
+    url = urlparse(origin)
+    return url.hostname in settings.ALLOWED_HOSTS
+
+
+def is_IP_allowed(ip_address: str | None) -> bool:
+    """Whether the IP address starts with withelisted IPV4 ranges."""
+    if ip_address is None:
+        return False
+    for ip_start in app_settings.API_WHITELIST_IPS:
+        if ip_address.startswith(ip_start):
+            return True
+    return False
+
+
+class TsosiThrottle(AnonRateThrottle):
+    """
+    Custom API throttler for all API requests.
+    Throttling is active by default except one of the following condition
+    is met:
+        - The request is originated by TSOSI front-end application.
+        - The requester IP is within a custom list of IP addresses.
+    """
+
+    rate = app_settings.API_RATE
+
+    def get_cache_key(self, request: Request, view):
+        origin = request.META.get("HTTP_ORIGIN") or request.META.get(
+            "HTTP_REFERER"
+        )
+        if is_origin_whitelist(origin):
+            return None
+
+        if is_IP_allowed(request.META.get("REMOTE_ADDR")):
+            return None
+
+        return super().get_cache_key(request, view)

--- a/backend/tsosi/app_settings.py
+++ b/backend/tsosi/app_settings.py
@@ -131,5 +131,22 @@ class AppSettings:
         """The number of days before refreshing existing wiki-related data."""
         return self._setting("WIKI_REFRESH_DAYS", 7)
 
+    @property
+    def API_WHITELIST_IPS(self) -> list[str]:
+        """
+        A list of IP prefix strings that should be whitelisted from rate
+        limiting.
+        This is a heuristic to whitelist whole subnet masks, working for UGA
+        because the known masks span exactly either 3 or 4 bytes.
+        """
+        return self._setting("API_WHITELIST_IPS", [])
+
+    @property
+    def API_RATE(self) -> str:
+        """
+        The rate limit for the API, defaults to 10 per minute.
+        """
+        return self._setting("API_RATE", "10/m")
+
 
 app_settings = AppSettings()


### PR DESCRIPTION
Implement default API rate limiting using DRF throttling functionnalities.
Default rate is 10 requests / minute for any.