### PR TITLE
[FIX] API Rate limiting - Add `DRF_NUM_PROXIES` local setting to adapt to server conf 

### DIFF
--- a/backend/backend_site/settings.py
+++ b/backend/backend_site/settings.py
@@ -21,6 +21,7 @@ from .settings_local import (
     DATABASES,
     DEBUG,
     DJANGO_LOG_LEVEL,
+    DRF_NUM_PROXIES,
     ERROR_LOG_FILE,
     MEDIA_ROOT,
     MEDIA_URL,
@@ -251,6 +252,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 20,
     "DEFAULT_THROTTLE_CLASSES": ["tsosi.api.throttle.TsosiThrottle"],
+    "NUM_PROXIES": DRF_NUM_PROXIES,
 }
 
 TSOSI_CELERY_ACCEPT_CONTENT = ["json"]

--- a/backend/backend_site/settings_local.dev.py
+++ b/backend/backend_site/settings_local.dev.py
@@ -51,6 +51,7 @@ CACHES = {
         "LOCATION": f"redis://{TSOSI_REDIS_HOST}:{TSOSI_REDIS_PORT}/{TSOSI_REDIS_DB}",
     }
 }
+DRF_NUM_PROXIES = 0
 
 if "test" in sys.argv or "pytest" in sys.modules:
     DATABASES["default"] = {"ENGINE": "django.db.backends.sqlite3"}

--- a/backend/tsosi/api/throttle.py
+++ b/backend/tsosi/api/throttle.py
@@ -1,12 +1,9 @@
-import logging
 from urllib.parse import urlparse
 
 from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.throttling import AnonRateThrottle
 from tsosi.app_settings import app_settings
-
-logger = logging.getLogger(__name__)
 
 
 def is_origin_whitelist(origin: str | None) -> bool:
@@ -24,7 +21,6 @@ def is_IP_allowed(ip_address: str | None) -> bool:
     # Only check IPV4 address string
     if len(ip_address.split(".")) != 4:
         return False
-    logger.info(f"Checking if IP address {ip_address} is allowed.")
     for ip_start in app_settings.API_WHITELIST_IPS:
         if ip_address.startswith(ip_start):
             return True


### PR DESCRIPTION
Production machine is being proxied by nginx to the gunicorn WSGI application when there's no proxy in basic local dev.
We need this information to infer the correct IP address when performing IP-based whitelisting.  